### PR TITLE
Removed Casting

### DIFF
--- a/Assets/Scenes/EventCallbackScene/DeathListener.cs
+++ b/Assets/Scenes/EventCallbackScene/DeathListener.cs
@@ -10,11 +10,11 @@ namespace EventCallbacks
         // Use this for initialization
         void Start()
         {
-            UnitDeathEvent.RegisterListener(OnUnitDied);
+            UnitDeathEvent.Listeners += (OnUnitDied);
         }
 
         void OnDestroy() {
-            UnitDeathEvent.UnregisterListener(OnUnitDied);
+            UnitDeathEvent.Listeners -= (OnUnitDied);
         }
 
         // Update is called once per frame

--- a/Assets/Scenes/EventCallbackScene/EventInfo.cs
+++ b/Assets/Scenes/EventCallbackScene/EventInfo.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using UnityEngine;
+
+namespace EventCallbacks
+{
+    public abstract class EventSystem<T>
+    {
+        /*
+         * The base Event,
+         * might have some generic text
+         * for doing Debug.Log?
+         */
+
+        public readonly string Description;
+
+        public EventSystem(string description)
+        {
+            Description = description;
+        }
+        
+        public delegate void EventListener(T info);
+        public static event EventListener Listeners;
+
+        protected void FireEvent(T info)
+        {
+            Listeners(info);
+        }
+    }
+
+    public class DebugEvent : EventSystem<DebugEvent>
+    {
+        public DebugEvent(int verbosityLevel) : base("Debug event.")
+        {
+            VerbosityLevel = verbosityLevel;
+            FireEvent(this);
+        }
+
+        public readonly int VerbosityLevel;
+    }
+
+    public class UnitDeathEvent : EventSystem<UnitDeathEvent>
+    {
+        public UnitDeathEvent(GameObject go) : base("Unit death event.")
+        {
+            UnitGO = go;
+            FireEvent(this);
+        }
+
+        public readonly GameObject UnitGO;
+        /*
+
+        Info about cause of death, our killer, etc...
+
+        Could be a struct, readonly, etc...
+
+        */
+    }
+}

--- a/Assets/Scenes/EventCallbackScene/Health.cs
+++ b/Assets/Scenes/EventCallbackScene/Health.cs
@@ -25,12 +25,7 @@ namespace EventCallbacks
         void Die()
         {
             // I am dying for some reason.
-
-            UnitDeathEvent udei = new UnitDeathEvent();
-            udei.Description = "Unit "+ gameObject.name +" has died.";
-            udei.UnitGO = gameObject;
-            udei.FireEvent();
-
+            new UnitDeathEvent(gameObject);
             Destroy(gameObject);
         }
     }


### PR DESCRIPTION
Casting is not needed FireEvent(this); will properly handle the types. FireEvent(this) is a protected method and cannot be called from outside the class. The event is fired at the end of the constructor. Creating an event is straightforward "new UnitDeathEvent(gameObject);". Listening to events is easy too, "UnitDeathEvent.Listeners += (OnUnitDied);". 